### PR TITLE
Mount workdir in docker container for awsbatch

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -378,9 +378,6 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
         result.setType(JobDefinitionType.Container)
 
         def mountPointPath = getAwsOptions().mountPoint
-        def tmpdir = new KeyValuePair()
-        tmpdir.setName("TMPDIR")
-        tmpdir.setValue(mountPointPath)
 
         // container definition
         def container = new ContainerProperties()
@@ -389,7 +386,6 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
                 .withCommand('true')
                 .withMemory(1024)
                 .withVcpus(1)
-                .withEnvironment([tmpdir])
 
         def awscli = getAwsOptions().cliPath
         def mounts = new LinkedList<MountPoint>()
@@ -427,7 +423,7 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
         result.setContainerProperties(container)
 
         // create a job marker uuid
-        def uuid = CacheHelper.hasher([name, image, awscli, tmpdir]).hash().toString()
+        def uuid = CacheHelper.hasher([name, image, awscli]).hash().toString()
         result.setParameters(['nf-token':uuid])
 
         return result

--- a/modules/nextflow/src/main/groovy/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cloud/aws/batch/AwsBatchTaskHandler.groovy
@@ -427,7 +427,7 @@ class AwsBatchTaskHandler extends TaskHandler implements BatchHandler<String,Job
         result.setContainerProperties(container)
 
         // create a job marker uuid
-        def uuid = CacheHelper.hasher([name, image, awscli]).hash().toString()
+        def uuid = CacheHelper.hasher([name, image, awscli, tmpdir]).hash().toString()
         result.setParameters(['nf-token':uuid])
 
         return result

--- a/modules/nextflow/src/main/groovy/nextflow/cloud/aws/batch/AwsOptions.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cloud/aws/batch/AwsOptions.groovy
@@ -42,6 +42,8 @@ class AwsOptions {
 
     String region
 
+    String mountPoint
+
     AwsOptions() { }
 
     AwsOptions(Session session) {
@@ -75,6 +77,15 @@ class AwsOptions {
             if( !value.startsWith('/') ) throw new ProcessUnrecoverableException("Not a valid aws-cli tools path: $value -- it must be an absolute path")
             if( !value.endsWith('/bin/aws')) throw new ProcessUnrecoverableException("Not a valid aws-cli tools path: $value -- it must end with the `/bin/aws` suffix")
             this.cliPath = value
+        }
+    }
+
+    void setMountPath(String value) {
+        if( !value )
+            this.mountPoint = '/tmp'
+        else {
+            if (!value.startsWith('/')) throw new ProcessUnrecoverableException("Not a valid mount path: $value -- it must be an absolute path")
+            this.mountPoint = value
         }
     }
 


### PR DESCRIPTION
Creating additional mount point in container to being able to utilize different partition for working directory. This helps with the IO problem which occurs with multiple jobs scheduled on on instance described [here](https://groups.google.com/forum/#!topic/nextflow/BXA-esz1eJ4).